### PR TITLE
Changed minimum Ruby version from 2.6.0 to 2.4.0 

### DIFF
--- a/html2asciimath.gemspec
+++ b/html2asciimath.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.add_runtime_dependency "nokogiri"
   spec.add_runtime_dependency "unicode_scanner", "~> 1.0"


### PR DESCRIPTION
[Workflow](https://github.com/plurimath/plurimath/runs/5017694090?check_suite_focus=true) is failing for Plurimath [PR](https://github.com/plurimath/plurimath/pull/3).

    plurimath was resolved to 0.1.0, which depends on
      html2asciimath was resolved to 0.1.0, which depends on
        Ruby (>= 2.6.0)

    plurimath was resolved to 0.1.0, which depends on
      Ruby (>= 2.3.0)

    rake (~> 12.0) was resolved to 12.3.3, which depends on
      Ruby (>= 2.0.0)
      
 <img width="347" alt="Screen Shot 2022-02-02 at 2 20 04 PM" src="https://user-images.githubusercontent.com/96812483/152126280-838ad3d3-b644-4fa8-b070-40e749bb415e.png">